### PR TITLE
chore: replace raw brew tap with p6df::core::homebrew::cmd::brew tap

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -21,7 +21,7 @@ p6df::modules::sqlserver::deps() {
 ######################################################################
 p6df::modules::sqlserver::external::brew() {
 
-  brew tap microsoft/mssql-release
+  p6df::core::homebrew::cmd::brew tap microsoft/mssql-release
   p6df::core::homebrew::cli::brew::install msodbcsql # XXX: fix prompt for EULA
   p6df::core::homebrew::cli::brew::install mssql-tools
 


### PR DESCRIPTION
## Summary
- Replaces raw `brew tap microsoft/mssql-release` with `p6df::core::homebrew::cmd::brew tap microsoft/mssql-release` in `external::brew()` hook

## Test plan
- [ ] CI build passes
- [ ] shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)