### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,11 +15,11 @@ p6df::modules::sqlserver::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::sqlserver::external::brew()
+# Function: p6df::modules::sqlserver::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::sqlserver::external::brew() {
+p6df::modules::sqlserver::external::brews() {
 
   p6df::core::homebrew::cmd::brew tap microsoft/mssql-release
   p6df::core::homebrew::cli::brew::install msodbcsql # XXX: fix prompt for EULA


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly