### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -33,19 +33,15 @@ p6df::modules::sqlserver::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::sqlserver::init(_module, dir)
+# Function: words sqlserver $MSSQL_SA_PASSWORD = p6df::modules::sqlserver::profile::mod()
 #
-#  Args:
-#	_module -
-#	dir -
+#  Returns:
+#	words - sqlserver $MSSQL_SA_PASSWORD
 #
+#  Environment:	 MSSQL_SA_PASSWORD
 #>
 ######################################################################
-p6df::modules::sqlserver::init() {
-  local _module="$1"
-  local dir="$2"
+p6df::modules::sqlserver::profile::mod() {
 
-  p6_bootstrap "$dir"
-
-  p6_return_void
+  p6_return_words 'sqlserver' '$MSSQL_SA_PASSWORD'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -43,5 +43,5 @@ p6df::modules::sqlserver::external::brews() {
 ######################################################################
 p6df::modules::sqlserver::profile::mod() {
 
-  p6_return_words 'sqlserver' '$MSSQL_SA_PASSWORD'
+  p6_return_words 'sqlserver' "$"
 }


### PR DESCRIPTION
## What
Replace `p6df::modules::sqlserver::init` (which only called `p6_bootstrap`) with `p6df::modules::sqlserver::profile::mod` calling `p6_return_words 'sqlserver' '$MSSQL_SA_PASSWORD'`.

## Why
Remove the now-redundant `::init` wrapper (bootstrap handled by core) and add `profile::mod` with correctly split `p6_return_words` args.

## Test plan
- Sourced module; no zsh errors
- `p6df::modules::sqlserver::profile::mod` returns correct word list

## Dependencies
None