### PR TITLE
fix(prompt): set MSSQL_SA_PASSWORD env var in profile::mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ TODO: Add a short summary of this module.
   - Args:
     - _module -
     - dir -
+- `words sqlserver $MSSQL_SA_PASSWORD = p6df::modules::sqlserver::profile::mod()`
 
 #### p6df-sqlserver/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -43,5 +43,5 @@ p6df::modules::sqlserver::external::brews() {
 ######################################################################
 p6df::modules::sqlserver::profile::mod() {
 
-  p6_return_words 'sqlserver' "$"
+  p6_return_words 'sqlserver' '$MSSQL_SA_PASSWORD'
 }


### PR DESCRIPTION
## What
Replace placeholder `"$"` with `'$MSSQL_SA_PASSWORD'` in `p6df::modules::sqlserver::profile::mod()` and update README.

## Why
The prompt word list was missing the actual environment variable, causing the prompt to display nothing useful.

## Test plan
- Inspected change manually

## Dependencies
None